### PR TITLE
Add Cog file to build Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 
 Piano transcription is the task of transcribing piano recordings into MIDI files. This repo is the PyTorch implementation of our proposed high-resolution piano transcription system [1].
 
+<a href="https://replicate.com/replicate/piano-transcription"><img src="https://replicate.com/replicate/piano-transcription/badge"></a>
+
 ## Demos
 Here is a demo of our piano transcription system: https://www.youtube.com/watch?v=5U-WL0QvKCg
+
+[Demo and Docker image on Replicate](https://replicate.ai/bytedance/piano-transcription)
 
 ## Environments
 This codebase is developed with Python 3.7 and PyTorch 1.4.0 (Should work with other versions, but not fully tested).

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,37 @@
+# Configuration for Cog ⚙️
+# Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
+
+build:
+  gpu: true
+
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+    - "libsndfile1-dev"
+    - "ffmpeg"
+    - "timidity"
+
+  python_version: "3.8"
+
+  python_packages:
+     - "torch==1.8.0"
+     - "torchvision==0.9.0"
+     - "piano_transcription_inference==0.0.5"
+     - "librosa==0.6.0"
+     - "h5py==2.10.0"
+     - "pandas==1.1.2"
+     - "librosa==0.6.0"
+     - "numba==0.48"
+     - "mido==1.2.9"
+     - "mir_eval==0.5"
+     - "matplotlib==3.0.3"
+     - "torchlibrosa==0.0.4"
+     - "sox==1.4.0"
+     - "tqdm==4.62.3"
+     - "pretty_midi==0.2.9"
+     - "synthviz==0.0.2"
+  
+  run:
+     - "ffmpeg -version"
+
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,42 @@
+# Prediction interface for Cog ⚙️
+# Reference: https://github.com/replicate/cog/blob/main/docs/python.md
+
+import os
+from pathlib import Path
+
+import cog
+import librosa
+
+# model repo: https://github.com/bytedance/piano_transcription
+# package repo: https://github.com/qiuqiangkong/piano_transcription_inference
+from piano_transcription_inference import PianoTranscription, sample_rate
+from synthviz import create_video
+
+# adapted from example: https://github.com/minzwon/sota-music-tagging-models/blob/master/predict.py
+
+
+class Predictor(cog.Predictor):
+    transcriptor: PianoTranscription
+
+    def setup(self):
+        self.transcriptor = PianoTranscription(
+            device="cuda", checkpoint_path="./model.pth"
+        )
+
+    @cog.input("audio_input", type=Path, help="Input audio file")
+    def predict(self, audio_input):
+        midi_intermediate_filename = "transcription.mid"
+        video_filename = os.path.join(Path.cwd(), "output.mp4")
+        audio, _ = librosa.core.load(str(audio_input), sr=sample_rate)
+        # Transcribe audio
+        self.transcriptor.transcribe(audio, midi_intermediate_filename)
+
+        # 'Visualization' output option
+        create_video(
+            input_midi=midi_intermediate_filename, video_filename=video_filename
+        )
+        print(
+            f"Created video of size {os.path.getsize(video_filename)} bytes at path {video_filename}"
+        )
+        # Return path to video
+        return Path(video_filename)


### PR DESCRIPTION
Hey @kongqiuqiang ! 👋 

I've been working with this model for awhile since it's one of the best open-source models for piano transcription. I recently started working with [Replicate](https://replicate.com/) to make machine learning models more reproducible. I wanted to make a cool demo for piano transcription, which ended up as [synthviz](https://github.com/jxmorris12/synthviz), a small Python package for making Synthesia-esque videos from piano transcription. I wrapped your model and my visualization up in a Docker environment (which is also available to try as a demo on Replicate). 

This pull request makes it possible to run your model inside a Docker environment, which makes it easier for other people to run it.  We're using an open source tool called [Cog](https://github.com/replicate/cog) to make this process easier.

This also means we can make a web page where other people can try out your model! View it here: https://replicate.com/bytedance/piano-transcription

[Claim your page here](https://replicate.com/bytedance) so you can edit it, and we'll feature it on our website and tweet about it too.